### PR TITLE
Add Nexus 3 staging support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -143,6 +143,88 @@ The following properties configure aspects of the release profile behavior:
 |skipReleaseAssembly|false|If `true`, the `-source-release` artifact will not be created.
 |===
 
+[id='staged-deployments']
+=== Staged releases
+
+By default, the `jboss-release` profile deploys artifacts to the configured Nexus 3 server using the `nxrm3-maven-plugin`'s `deploy` goal.
+The usual expectation when that goal is used is that the repository to which the artifacts are deployed will be their ultimate location,
+where typical Maven clients will access them. However, the `nxrm3-maven-plugin` also support stage->validate->promote workflows with
+its `staging-deploy`, `staging-move` and `staging-delete` goals.
+
+The parent POM includes three Maven profiles -- `jboss-staging-deploy`, `jboss-staging-move` and `jboss-staging-delete` -- to support use of these goals.
+
+The following property is used by all three profiles:
+
+[cols="1m,1m,2",options="header"]
+|===
+|Property|Default|Description
+|nexus.staging.tag|empty string|Tag to associate with all deployed artifacts. An empty string results in a plugin-generated tag.
+|===
+
+A typical good practice would be to set this property in a child pom to a combination of a unique-to-the-project string and the release version:
+
+.Usage example for the `nexus.staging.tag` property
+[source,xml]
+----
+<nexus.staging.tag>project-foo-${project.version}</nexus.staging.tag>
+----
+
+[id='the-jboss-staging-deploy-profile']
+==== The JBoss Staging Deploy Profile
+
+To deploy to a staging repository, use the `jboss-staging-deploy` profile in combination with the `jboss-release` profile.
+
+.Usage example for the `jboss-staging-deploy` profile
+[source,bash]
+----
+mvn -Pjboss-release -Pjboss-staging-deploy deploy
+----
+
+All deployed artifacts will have an associated tag, with the value of the `nexus.staging.tag` Maven property, or a generated value the property is not configured.
+This tag is later used to identify artifacts to move from the staging repository to their final destination, or to delete them from the staging repository.
+
+[id='the-jboss-staging-move-profile']
+==== The JBoss Staging Move Profile
+
+Once the build that used the `jboss-staging-deploy` profile is complete, the staged artifacts can be validated. If they are acceptable, they can be moved from
+the staging repository to the final repository where typical Maven clients will access them.
+
+This move is accomplished by a `mvn` execution that executes a single nxrm3-maven-plugin goal, with the parent POM's `jboss-staging-move` profile enabled to help
+configure the execution of that goal:
+
+.Usage example for the `jboss-staging-move` profile
+[source,bash]
+----
+mvn -Pjboss-staging-move nxrm3:staging-move
+----
+
+The following property is used by the `jboss-staging-move` profile:
+
+[cols="1m,2",options="header"]
+|===
+|Property|Description
+|nexus.destination.repo.name|The name of the repository to move the tagged artifacts to
+|===
+
+The `jboss-staging-move` profile also uses the `nexus.staging.tag` property described earlier to determine the tag identifying the artifacts that should be moved.
+
+[id='the-jboss-staging-delete-profile']
+==== The JBoss Staging Delete Profile
+
+If the build that used the `jboss-staging-deploy` profile did not complete successfully, or if the deployed artifacts are otherwise not suitable for promotion from 
+the staging repo, they can be deleted from the staging repository.
+
+This move is accomplished by a `mvn` execution that executes a single mxrm3-mavcen-plugin goal, with the parent POM's `jboss-staging-delete` profile enabled to help
+configure the execution of that goal:
+
+.Usage example for the `jboss-staging-delete` profile
+[source,bash]
+----
+mvn -Pjboss-staging-delete nxrm3:staging-delete
+----
+
+The `jboss-staging-delete` profile uses the `nexus.staging.tag` property described earlier to determine the tag identifying the artifacts that should be moved.
+
 [id='the-gpg-sign-profile']
 == The GPG Sign Profile
 

--- a/pom.xml
+++ b/pom.xml
@@ -141,11 +141,13 @@
       <version.surefire>3.5.3</version.surefire>
 
       <!-- ***************** -->
-      <!-- Repository Deployment URLs -->
+      <!-- Repository Deployment Settings -->
       <!-- ***************** -->
       <nexus.serverId>jboss</nexus.serverId>
       <nexus.repo.name>releases</nexus.repo.name>
       <nexus.repo.url>https://repository.jboss.org/nexus3</nexus.repo.url>
+      <nexus.destination.repo.name></nexus.destination.repo.name>
+      <nexus.staging.tag></nexus.staging.tag> <!-- an empty value results in a plugin-generated staging tag -->
 
       <!-- ************** -->
       <!-- Build settings -->
@@ -187,6 +189,7 @@
       <!-- maven-gpg-plugin -->
       <!-- set this to "error" to require a GPG agent-->
       <gpg.pinEntryMode>loopback</gpg.pinEntryMode>
+
     </properties>
 
     <build>
@@ -399,6 +402,13 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
             <version>${version.gpg.plugin}</version>
+            <configuration>
+              <useAgent>true</useAgent>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>${gpg.pinEntryMode}</arg>
+              </gpgArguments>
+            </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -498,6 +508,11 @@
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nxrm3-maven-plugin</artifactId>
             <version>${version.nxrm3.plugin}</version>
+            <configuration>
+              <serverId>${nexus.serverId}</serverId>
+              <nexusUrl>${nexus.repo.url}</nexusUrl>
+              <repository>${nexus.repo.name}</repository>
+            </configuration>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -851,11 +866,6 @@
               <groupId>org.sonatype.plugins</groupId>
               <artifactId>nxrm3-maven-plugin</artifactId>
               <extensions>true</extensions>
-              <configuration>
-                <serverId>${nexus.serverId}</serverId>
-                <nexusUrl>${nexus.repo.url}</nexusUrl>
-                <repository>${nexus.repo.name}</repository>
-              </configuration>
               <executions>
                 <execution>
                   <id>nexus-deploy</id>
@@ -869,13 +879,6 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
-              <configuration>
-                <useAgent>true</useAgent>
-                <gpgArguments>
-                  <arg>--pinentry-mode</arg>
-                  <arg>${gpg.pinEntryMode}</arg>
-                </gpgArguments>
-              </configuration>
               <executions>
                 <execution>
                   <id>gpg-sign</id>
@@ -900,6 +903,75 @@
           </plugins>
         </build>
       </profile>
+      <!-- Use this profile in combination with 'jboss-release' to use
+           the nxrm3-maven-plugin's 'staging-deploy' goal instead of its
+           'deploy' goal. Once the staged deployment is valdated, the
+           person or script doing the release  would move on to use
+           its 'staging-move' goal via a call to
+           'mvn nxrm3:staging-move -Pjboss-staging-move' -->
+      <profile>
+        <id>jboss-staging-deploy</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nxrm3-maven-plugin</artifactId>
+              <executions>
+                <!-- Disable the jboss-release profile's 'deploy' goal execution -->
+                <execution>
+                  <id>nexus-deploy</id>
+                  <phase>none</phase>
+                </execution>
+                <execution>
+                  <id>nexus-staging.deploy</id>
+                  <phase>deploy</phase>
+                  <goals>
+                    <goal>staging-deploy</goal>
+                  </goals>
+                  <configuration>
+                    <tag>${nexus.staging.tag}</tag>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+      <!-- Used in release workflows that use the 'jboss-staging-deploy' profile,
+           this profile configures the nxrm3-maven-plugin to support command
+           line execution of its 'staging-move' goal. -->
+      <profile>
+        <id>jboss-staging-move</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nxrm3-maven-plugin</artifactId>
+              <configuration>
+                <destinationRepository>${nexus.destination.repo.name}</destinationRepository>
+                <tag>${nexus.staging.tag}</tag>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
+      <!-- Used in release workflows that use the 'jboss-staging-deploy' profile,
+           this profile configures the nxrm3-maven-plugin to support command
+           line execution of its 'staging-delete' goal. -->
+      <profile>
+        <id>jboss-staging-delete</id>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.sonatype.plugins</groupId>
+              <artifactId>nxrm3-maven-plugin</artifactId>
+              <configuration>
+                <tag>${nexus.staging.tag}</tag>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+      </profile>
       <!--
           This profile can be activated to generate gpg signatures for all build
           artifacts.  This profile requires that the properties "gpg.keyname"
@@ -917,13 +989,6 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-gpg-plugin</artifactId>
-              <configuration>
-                <useAgent>true</useAgent>
-                <gpgArguments>
-                  <arg>--pinentry-mode</arg>
-                  <arg>${gpg.pinEntryMode}</arg>
-                </gpgArguments>
-              </configuration>
               <executions>
                 <execution>
                   <id>gpg-sign</id>


### PR DESCRIPTION
As discussed at https://github.com/jboss/jboss-parent-pom/pull/415

I've not been able to validate this yet. The Nexus 3 JBoss Nexus playground set up to let projects get ready for the main JBoss Nexus move to Nexus 3 is disabled. I tried testing will an eval copy of Nexus 3 but their eval copies don't provide the staging functionality this uses.

So I think we'll need to wait until the Nexus 3 variant of JBoss Nexus is live.

Once we can, I plan to basically copy the jboss-release profile and the 3 I add here into a couple projects and do alpha or beta releases. That will validate the behavior.